### PR TITLE
[JOJI-875] feat: duration 편집 기능 추가

### DIFF
--- a/src/client/widgets/blocks/MultipleImageAndSingleTextBlock.tsx
+++ b/src/client/widgets/blocks/MultipleImageAndSingleTextBlock.tsx
@@ -1,3 +1,6 @@
+import { Input } from "@/src/client/shared/shadcn/components/input";
+import { Label } from "@/src/client/shared/shadcn/components/label";
+import { TypographySmall } from "@/src/client/shared/shadcn/components/typography";
 import { ImageBlock } from "@/src/client/widgets/blocks/ImageBlock";
 import { TextBlock } from "@/src/client/widgets/blocks/TextBlock";
 import { MultipleImageAndSingleTextBlock as MultipleImageAndSingleTextBlockType } from "@/src/common/model/blocks";
@@ -32,9 +35,22 @@ function EditableMultipleImageAndSingleTextBlock({
   block,
   onChange,
 }: Omit<MultipleImageAndSingleTextBlockProps<true>, "isEditable">) {
-  const { imageBlocks, textBlock } = block;
+  const { imageBlocks, textBlock, duration } = block;
   return (
     <div>
+      <div className="p-2">
+        <Label>
+          <TypographySmall>duration(초):</TypographySmall>
+          <Input
+            type="number"
+            value={duration}
+            onChange={(e) => {
+              onChange?.({ ...block, duration: parseInt(e.target.value) });
+            }}
+          />
+        </Label>
+      </div>
+
       <div className="flex gap-4">
         <div className="space-y-2">
           {imageBlocks.map((imageBlock, index) => (
@@ -58,6 +74,7 @@ function EditableMultipleImageAndSingleTextBlock({
           <TextBlock
             block={textBlock}
             isEditable={true}
+            isShowDuration={false}
             onChange={(newTextBlock) => {
               onChange?.({
                 ...block,
@@ -74,19 +91,31 @@ function EditableMultipleImageAndSingleTextBlock({
 function ReadOnlyMultipleImageAndSingleTextBlock({
   block,
 }: Omit<MultipleImageAndSingleTextBlockProps<false>, "isEditable">) {
-  const { imageBlocks, textBlock } = block;
+  const { imageBlocks, textBlock, duration } = block;
 
   return (
-    <div className="flex gap-4">
-      <div className="space-y-2">
-        {imageBlocks.map((imageBlock, index) => (
-          <div key={index} className="rounded-lg border p-2">
-            <ImageBlock block={imageBlock} isEditable={false} />
-          </div>
-        ))}
+    <div>
+      <div className="p-2">
+        <Label>
+          <TypographySmall>duration(초):</TypographySmall>
+          {duration}초
+        </Label>
       </div>
-      <div>
-        <TextBlock block={textBlock} isEditable={false} />
+      <div className="flex gap-4">
+        <div className="space-y-2">
+          {imageBlocks.map((imageBlock, index) => (
+            <div key={index} className="rounded-lg border p-2">
+              <ImageBlock block={imageBlock} isEditable={false} />
+            </div>
+          ))}
+        </div>
+        <div>
+          <TextBlock
+            block={textBlock}
+            isEditable={false}
+            isShowDuration={false}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/client/widgets/blocks/SingleImageAndMultipleTextBlock.tsx
+++ b/src/client/widgets/blocks/SingleImageAndMultipleTextBlock.tsx
@@ -1,3 +1,5 @@
+import { Label } from "@/src/client/shared/shadcn/components/label";
+import { TypographySmall } from "@/src/client/shared/shadcn/components/typography";
 import { ImageBlock } from "@/src/client/widgets/blocks/ImageBlock";
 import { TextBlock } from "@/src/client/widgets/blocks/TextBlock";
 import { SingleImageAndMultipleTextBlock as SingleImageAndMultipleTextBlockType } from "@/src/common/model/blocks";
@@ -39,6 +41,7 @@ function EditableSingleImageAndMultipleTextBlock({
       <ImageBlock
         block={imageBlock}
         isEditable={true}
+        isShowDuration={false}
         onChange={(newImageBlock) => {
           onChange?.({
             ...block,
@@ -71,16 +74,28 @@ function EditableSingleImageAndMultipleTextBlock({
 function ReadOnlySingleImageAndMultipleTextBlock({
   block,
 }: Omit<SingleImageAndMultipleTextBlockProps<false>, "isEditable">) {
-  const { imageBlock, textBlocks } = block;
+  const { imageBlock, textBlocks, duration } = block;
   return (
-    <div className="flex gap-4">
-      <ImageBlock block={imageBlock} isEditable={false} />
-      <div className="space-y-2">
-        {textBlocks.map((textBlock, index) => (
-          <div key={index} className="rounded-lg border p-2">
-            <TextBlock block={textBlock} isEditable={false} />
-          </div>
-        ))}
+    <div>
+      <div className="p-2">
+        <Label>
+          <TypographySmall>duration(초):</TypographySmall>
+          {duration}초
+        </Label>
+      </div>
+      <div className="flex gap-4">
+        <ImageBlock
+          block={imageBlock}
+          isEditable={false}
+          isShowDuration={false}
+        />
+        <div className="space-y-2">
+          {textBlocks.map((textBlock, index) => (
+            <div key={index} className="rounded-lg border p-2">
+              <TextBlock block={textBlock} isEditable={false} />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/client/widgets/blocks/SingleImageAndSingleTextBlock.tsx
+++ b/src/client/widgets/blocks/SingleImageAndSingleTextBlock.tsx
@@ -1,3 +1,6 @@
+import { Input } from "@/src/client/shared/shadcn/components/input";
+import { Label } from "@/src/client/shared/shadcn/components/label";
+import { TypographySmall } from "@/src/client/shared/shadcn/components/typography";
 import { ImageBlock } from "@/src/client/widgets/blocks/ImageBlock";
 import { TextBlock } from "@/src/client/widgets/blocks/TextBlock";
 import { SingleImageAndSingleTextBlock as SingleImageAndSingleTextBlockType } from "@/src/common/model/blocks";
@@ -33,27 +36,43 @@ function EditableSingleImageAndSingleTextBlock({
   const { imageBlock, textBlock } = block;
 
   return (
-    <div className="flex gap-4">
-      <ImageBlock
-        block={imageBlock}
-        isEditable={true}
-        onChange={(newImageBlock) => {
-          onChange?.({
-            ...block,
-            imageBlock: newImageBlock,
-          });
-        }}
-      />
-      <TextBlock
-        block={textBlock}
-        isEditable={true}
-        onChange={(newTextBlock) => {
-          onChange?.({
-            ...block,
-            textBlock: newTextBlock,
-          });
-        }}
-      />
+    <div>
+      <div className="p-2">
+        <Label>
+          <TypographySmall>duration(초):</TypographySmall>
+          <Input
+            type="number"
+            value={block.duration}
+            onChange={(e) =>
+              onChange?.({ ...block, duration: parseInt(e.target.value) })
+            }
+          />
+        </Label>
+      </div>
+      <div className="flex gap-4">
+        <ImageBlock
+          block={imageBlock}
+          isEditable={true}
+          isShowDuration={false}
+          onChange={(newImageBlock) => {
+            onChange?.({
+              ...block,
+              imageBlock: newImageBlock,
+            });
+          }}
+        />
+        <TextBlock
+          block={textBlock}
+          isEditable={true}
+          isShowDuration={false}
+          onChange={(newTextBlock) => {
+            onChange?.({
+              ...block,
+              textBlock: newTextBlock,
+            });
+          }}
+        />
+      </div>
     </div>
   );
 }
@@ -63,9 +82,23 @@ function ReadOnlySingleImageAndSingleTextBlock({
 }: Omit<SingleImageAndSingleTextBlockProps<false>, "isEditable">) {
   const { imageBlock, textBlock } = block;
   return (
-    <div className="flex gap-4">
-      <ImageBlock block={imageBlock} isEditable={false} />
-      <TextBlock block={textBlock} isEditable={false} />
+    <div>
+      <div className="p-2">
+        <TypographySmall>duration(초):</TypographySmall>
+        <TypographySmall>{block.duration}초</TypographySmall>
+      </div>
+      <div className="flex gap-4">
+        <ImageBlock
+          block={imageBlock}
+          isEditable={false}
+          isShowDuration={false}
+        />
+        <TextBlock
+          block={textBlock}
+          isEditable={false}
+          isShowDuration={false}
+        />
+      </div>
     </div>
   );
 }

--- a/src/client/widgets/blocks/TextBlock.tsx
+++ b/src/client/widgets/blocks/TextBlock.tsx
@@ -1,44 +1,81 @@
+import { Input } from "@/src/client/shared/shadcn/components/input";
+import { Label } from "@/src/client/shared/shadcn/components/label";
 import { Textarea } from "@/src/client/shared/shadcn/components/textarea";
-import { Typography } from "@/src/client/shared/shadcn/components/typography";
+import {
+  Typography,
+  TypographySmall,
+} from "@/src/client/shared/shadcn/components/typography";
 import { TextBlock as TextBlockType } from "@/src/common/model/blocks";
 
 export interface TextBlockProps<IsEditable extends boolean> {
   block: TextBlockType;
   isEditable: IsEditable;
+  isShowDuration?: boolean;
   onChange?: IsEditable extends true ? (block: TextBlockType) => void : never;
 }
 
 export function TextBlock<IsEditable extends boolean>({
   block,
   isEditable,
+  isShowDuration = true,
   onChange,
 }: TextBlockProps<IsEditable>) {
   if (isEditable) {
-    return <EditableTextBlock block={block} onChange={onChange} />;
+    return (
+      <EditableTextBlock
+        block={block}
+        isShowDuration={isShowDuration}
+        onChange={onChange}
+      />
+    );
   }
-  return <ReadOnlyTextBlock block={block} />;
+  return <ReadOnlyTextBlock block={block} isShowDuration={isShowDuration} />;
 }
 
 export function ReadOnlyTextBlock({
   block,
+  isShowDuration,
 }: Omit<TextBlockProps<false>, "onChange" | "isEditable">) {
   return (
     <div className="p-2">
-      <Typography.P>{block.value}</Typography.P>
+      <div className="flex flex-col gap-2">
+        {isShowDuration && (
+          <TypographySmall>
+            <span className="text-muted-foreground">duration(초):</span>{" "}
+            {block.duration}초
+          </TypographySmall>
+        )}
+        <Typography.P>{block.value}</Typography.P>
+      </div>
     </div>
   );
 }
 
 export function EditableTextBlock({
   block,
+  isShowDuration,
   onChange,
 }: Omit<TextBlockProps<true>, "isEditable">) {
   return (
     <div className="p-2">
-      <Textarea
-        value={block.value}
-        onChange={(e) => onChange?.({ ...block, value: e.target.value })}
-      />
+      <div className="flex flex-col gap-2">
+        {isShowDuration && (
+          <Label>
+            <TypographySmall>duration(초):</TypographySmall>
+            <Input
+              type="number"
+              value={block.duration}
+              onChange={(e) =>
+                onChange?.({ ...block, duration: parseInt(e.target.value) })
+              }
+            />
+          </Label>
+        )}
+        <Textarea
+          value={block.value}
+          onChange={(e) => onChange?.({ ...block, value: e.target.value })}
+        />
+      </div>
     </div>
   );
 }

--- a/src/common/model/blocks/common-block.model.ts
+++ b/src/common/model/blocks/common-block.model.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const commonBlockModel = z.object({
+  type: z.string(),
+  duration: z.number(),
+});
+
+export type CommonBlock = z.infer<typeof commonBlockModel>;

--- a/src/common/model/blocks/image-block.model.ts
+++ b/src/common/model/blocks/image-block.model.ts
@@ -1,7 +1,8 @@
+import { commonBlockModel } from "@/src/common/model/blocks/common-block.model";
 import { imageAnalysisModel } from "@/src/common/model/image-analysis.model";
 import { z } from "zod";
 
-export const imageBlockModel = z.object({
+export const imageBlockModel = commonBlockModel.extend({
   type: z.literal("image"),
   value: z.object({
     src: z.string(),

--- a/src/common/model/blocks/multiple-image-single-text-block.model.ts
+++ b/src/common/model/blocks/multiple-image-single-text-block.model.ts
@@ -1,3 +1,4 @@
+import { commonBlockModel } from "@/src/common/model/blocks/common-block.model";
 import { z } from "zod";
 import {
   imageBlockModel,
@@ -5,9 +6,8 @@ import {
 } from "./image-block.model";
 import { textBlockModel } from "./text-block.model";
 
-export const multipleImageAndSingleTextBlockModel = z.object({
+export const multipleImageAndSingleTextBlockModel = commonBlockModel.extend({
   type: z.literal("multipleImageAndSingleText"),
-  duration: z.number(),
   imageBlocks: z.array(imageBlockModel),
   textBlock: textBlockModel,
 });

--- a/src/common/model/blocks/single-image-multiple-text-block.model.ts
+++ b/src/common/model/blocks/single-image-multiple-text-block.model.ts
@@ -1,3 +1,4 @@
+import { commonBlockModel } from "@/src/common/model/blocks/common-block.model";
 import { z } from "zod";
 import {
   imageBlockModel,
@@ -5,9 +6,8 @@ import {
 } from "./image-block.model";
 import { textBlockModel } from "./text-block.model";
 
-export const singleImageAndMultipleTextBlockModel = z.object({
+export const singleImageAndMultipleTextBlockModel = commonBlockModel.extend({
   type: z.literal("singleImageAndMultipleText"),
-  duration: z.number(),
   imageBlock: imageBlockModel,
   textBlocks: z.array(textBlockModel),
 });

--- a/src/common/model/blocks/single-image-single-text-block.model.ts
+++ b/src/common/model/blocks/single-image-single-text-block.model.ts
@@ -1,3 +1,4 @@
+import { commonBlockModel } from "@/src/common/model/blocks/common-block.model";
 import { z } from "zod";
 import {
   imageBlockModel,
@@ -5,9 +6,8 @@ import {
 } from "./image-block.model";
 import { textBlockModel } from "./text-block.model";
 
-export const singleImageAndSingleTextBlockModel = z.object({
+export const singleImageAndSingleTextBlockModel = commonBlockModel.extend({
   type: z.literal("singleImageAndSingleText"),
-  duration: z.number(),
   imageBlock: imageBlockModel,
   textBlock: textBlockModel,
 });

--- a/src/common/model/blocks/text-block.model.ts
+++ b/src/common/model/blocks/text-block.model.ts
@@ -1,6 +1,7 @@
+import { commonBlockModel } from "@/src/common/model/blocks/common-block.model";
 import { z } from "zod";
 
-export const textBlockModel = z.object({
+export const textBlockModel = commonBlockModel.extend({
   type: z.literal("text"),
   value: z.string(),
 });

--- a/src/server/blog-parser/naver-blog-parser.ts
+++ b/src/server/blog-parser/naver-blog-parser.ts
@@ -158,6 +158,7 @@ export class NaverBlogParser implements BlogParser {
       value: {
         src: src ?? "",
       },
+      duration: 0,
     });
 
     return imageBlock;
@@ -176,6 +177,7 @@ export class NaverBlogParser implements BlogParser {
     const textBlock = textBlockModel.parse({
       type: "text",
       value: trimmedText,
+      duration: 0,
     });
 
     return textBlock;

--- a/src/server/blog-parser/ti-story-blog-parser.ts
+++ b/src/server/blog-parser/ti-story-blog-parser.ts
@@ -134,6 +134,7 @@ export class TiStoryBlogParser implements BlogParser {
       {
         type: "text",
         value: trimmedText,
+        duration: 0,
       },
     ];
   }
@@ -156,6 +157,7 @@ export class TiStoryBlogParser implements BlogParser {
     return srcs.map((src) => ({
       type: "image",
       value: { src },
+      duration: 0,
     }));
   }
 

--- a/src/server/video-converter/service/blog-to-video-job.service.ts
+++ b/src/server/video-converter/service/blog-to-video-job.service.ts
@@ -62,7 +62,7 @@ export class BlogToVideoJobService {
               sceneId,
               block.imageBlock.value.src,
               textBlock.value,
-              block.duration / block.textBlocks.length
+              textBlock.duration
             )
           );
           break;
@@ -74,19 +74,21 @@ export class BlogToVideoJobService {
               sceneId,
               imageBlock.value.src,
               block.textBlock.value,
-              block.duration / block.imageBlocks.length
+              imageBlock.duration
             )
           );
           break;
 
         case "text":
           // 텍스트만 있는 경우 배경색이 있는 화면에 텍스트 표시
-          cuts = [this.createCutFromText(sceneId, block.value, 3)]; // 기본 3초 지속
+          cuts = [this.createCutFromText(sceneId, block.value, block.duration)];
           break;
 
         case "image":
           // 이미지만 있는 경우
-          cuts = [this.createCutFromImage(sceneId, block.value.src, 3)]; // 기본 3초 지속
+          cuts = [
+            this.createCutFromImage(sceneId, block.value.src, block.duration),
+          ];
           break;
       }
 


### PR DESCRIPTION
# refactor: common-block 추가 및 모든 블럭에 duration 프로퍼티 추가

- 모든 블록 타입이 공통으로 사용하는 속성을 `commonBlockModel`로 추출
- 모든 블록 타입에 `duration` 속성 추가

# feat: duration 편집 기능 클라이언트 개발

- 각 블록 컴포넌트에 `isShowDuration` 옵션 추가
- 블록 편집 UI에 duration 입력 필드 추가
- 읽기 전용 모드에서 duration 표시 기능 구현

# feat: 블록 타입별 duration 처리 방식 변경

- 복합 블록(이미지+텍스트)에서 개별 블록별로 duration 관리하도록 변경
- 비디오 변환 서비스에서 각 블록의 duration 값을 직접 사용하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 이미지, 텍스트, 및 혼합 콘텐츠 블록에서 지속시간(duration)을 조건부로 표시할 수 있는 옵션이 추가되었습니다.
  - 편집 모드에서는 숫자 입력란을 통해 지속시간을 직접 업데이트할 수 있으며, 읽기 전용 모드에서는 설정된 값이 표시됩니다.
  - 영상 변환 기능이 각 블록의 지속시간을 반영하여 보다 정밀한 컷 분할을 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->