### PR TITLE
feat: header, footer 추가

### DIFF
--- a/src/server/video-converter/examples/README.md
+++ b/src/server/video-converter/examples/README.md
@@ -1,0 +1,57 @@
+# 비디오 렌더링 예제
+
+이 디렉토리에는 header, subtitle, footer 텍스트 레이아웃으로 비디오를 렌더링하는 예제 코드가 포함되어 있습니다.
+
+## 파일 설명
+
+- `video-cuts-fixture.json`: 비디오 컷 테스트 데이터
+- `render-video-cuts-example.ts`: 비디오 컷을 렌더링하는 예제 코드
+
+## 실행 방법
+
+1. 프로젝트 루트 디렉토리에서 다음 명령어를 실행합니다:
+
+```bash
+# TypeScript 컴파일 (필요한 경우)
+npm run build
+
+# 예제 실행
+node dist/server/video-converter/examples/render-video-cuts-example.js
+```
+
+또는 ts-node를 사용하여 직접 실행할 수 있습니다:
+
+```bash
+npx ts-node src/server/video-converter/examples/render-video-cuts-example.ts
+```
+
+## 결과
+
+실행이 완료되면 `output` 디렉토리에 다음 파일들이 생성됩니다:
+
+- 각 비디오 컷에 대한 MP4 파일 (`cut-xxx.mp4`)
+- 모든 컷을 합친 최종 비디오 파일 (`scene-final.mp4`)
+
+## 커스터마이징
+
+`video-cuts-fixture.json` 파일을 수정하여 다양한 텍스트와 이미지로 테스트할 수 있습니다.
+
+### VideoCut 형식
+
+```json
+{
+  "id": "cut-001",
+  "sceneId": "scene-001",
+  "duration": 5,
+  "imageUrl": "이미지 URL",
+  "header": "상단에 표시될 텍스트",
+  "subtitle": "중앙에 표시될 텍스트",
+  "footer": "하단에 표시될 텍스트"
+}
+```
+
+## 참고사항
+
+- 이미지 URL은 로컬 파일 경로나 웹 URL 모두 사용 가능합니다.
+- 텍스트에는 `\n`을 사용하여 줄바꿈을 추가할 수 있습니다.
+- FFmpeg가 시스템에 설치되어 있어야 이 예제가 작동합니다.

--- a/src/server/video-converter/examples/render-example.ts
+++ b/src/server/video-converter/examples/render-example.ts
@@ -43,7 +43,7 @@ async function renderExample() {
   const videoCut: VideoCut = {
     id: "example-1",
     sceneId: "scene-1",
-    text: "안녕하세요! 맞춤 설정 텍스트입니다.",
+    subtitle: "안녕하세요! 맞춤 설정 텍스트입니다.",
     duration: 5,
     // 이미지가 없으면 검정 배경 사용
     imageUrl: undefined,
@@ -74,7 +74,7 @@ async function renderExample() {
         ...videoCut,
         id: "example-2",
         sceneId: "scene-2",
-        text: "세로 방향 비디오 예시",
+        subtitle: "세로 방향 비디오 예시",
       },
       portraitOutput
     );

--- a/src/server/video-converter/examples/render-video-cuts-example.ts
+++ b/src/server/video-converter/examples/render-video-cuts-example.ts
@@ -1,0 +1,82 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { FFmpegRenderer } from "../ffmpeg/ffmpeg-renderer";
+import { VideoCut } from "../model/video-cut.model";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * 비디오 컷 렌더링 예제
+ *
+ * 이 예제는 video-cuts-fixture.json 파일을 읽어서
+ * FFmpegRenderer를 사용하여 비디오를 렌더링하는 방법을 보여줍니다.
+ */
+async function renderVideoExample() {
+  try {
+    // 1. 출력 디렉토리 설정
+    const outputDir = path.join(process.cwd(), "public/videos");
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    // 2. Fixture JSON 파일 로드
+
+    const fixtureFilePath = path.join(__dirname, "video-cuts-fixture.json");
+    const fixtureData = JSON.parse(fs.readFileSync(fixtureFilePath, "utf8"));
+    const cuts: VideoCut[] = fixtureData.cuts;
+
+    console.log(`총 ${cuts.length}개의 비디오 컷을 렌더링합니다.`);
+
+    // 3. FFmpegRenderer 초기화
+    const renderer = new FFmpegRenderer({
+      outputDir,
+      debug: true,
+      renderOptions: {
+        resolution: { width: 1080, height: 1920 },
+        fps: 30,
+      },
+    });
+
+    // 4. 각 컷 렌더링
+    const cutOutputPaths: string[] = [];
+    for (const [index, cut] of cuts.entries()) {
+      console.log(`[${index + 1}/${cuts.length}] 컷 렌더링: ${cut.id}`);
+
+      const outputFileName = `cut-${cut.id}.mp4`;
+      const outputPath = path.join(outputDir, outputFileName);
+
+      const renderedPath = await renderer.renderVideoCut(cut, outputPath);
+      cutOutputPaths.push(renderedPath);
+
+      console.log(`컷 렌더링 완료: ${renderedPath}`);
+    }
+
+    // 5. 모든 컷을 하나의 장면으로 합치기
+    const sceneOutputPath = path.join(outputDir, "scene-final.mp4");
+    const finalVideoPath = await renderer.concatSceneCuts(
+      cutOutputPaths,
+      sceneOutputPath
+    );
+
+    console.log(`최종 비디오 파일이 생성되었습니다: ${finalVideoPath}`);
+    console.log("렌더링이 완료되었습니다!");
+
+    return finalVideoPath;
+  } catch (error) {
+    console.error("렌더링 중 오류가 발생했습니다:", error);
+    throw error;
+  }
+}
+
+console.log("비디오 렌더링 예제를 시작합니다...");
+renderVideoExample()
+  .then((outputPath) => {
+    console.log(`작업이 완료되었습니다. 결과 파일: ${outputPath}`);
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error("예제 실행 중 오류가 발생했습니다:", error);
+    process.exit(1);
+  });

--- a/src/server/video-converter/examples/video-cuts-fixture.json
+++ b/src/server/video-converter/examples/video-cuts-fixture.json
@@ -1,0 +1,31 @@
+{
+  "cuts": [
+    {
+      "id": "cut-001",
+      "sceneId": "scene-001",
+      "duration": 5,
+      "imageUrl": "https://images.unsplash.com/photo-1583337130417-3346a1be7dee?q=80&w=1920",
+      "header": "속초 리모델링 사례",
+      "subtitle": "언니가 운영하던 오래된 슐집이에요.\n처음엔 그냥 바닥만 리뉴얼할 생각이었죠",
+      "footer": "@훈인테리어"
+    },
+    {
+      "id": "cut-002",
+      "sceneId": "scene-001",
+      "duration": 5,
+      "imageUrl": "https://images.unsplash.com/photo-1554118811-1e0d58224f24?q=80&w=1920",
+      "header": "속초 카페 리모델링",
+      "subtitle": "20년된 건물이라 바닥, 벽, 천장까지\n모두 손봐야 했습니다",
+      "footer": "@훈인테리어"
+    },
+    {
+      "id": "cut-003",
+      "sceneId": "scene-001",
+      "duration": 5,
+      "imageUrl": "https://images.unsplash.com/photo-1622547748225-3fc4abd2cca0?q=80&w=1920",
+      "header": "완성된 모습",
+      "subtitle": "작업 기간: 3주\n총 예산: 2800만원",
+      "footer": "@훈인테리어"
+    }
+  ]
+}

--- a/src/server/video-converter/ffmpeg/ffmpeg-renderer.ts
+++ b/src/server/video-converter/ffmpeg/ffmpeg-renderer.ts
@@ -144,15 +144,59 @@ export class FFmpegRenderer {
       .withOutputOptions()
       .withStartListener()
       .withProgressListener()
-      .withResizeFilter()
-      .withTextFilter(
-        this.#renderOptions.createTextFilterString(
-          this.#fontPath,
-          cut.text ?? ""
-        )
-      )
-      .applyFilters()
-      .withOutput();
+      .withResizeFilter();
+
+    // 헤더 텍스트 필터 추가 (상단)
+    if (cut.header) {
+      const headerStyle = {
+        ...this.#renderOptions.getOptions().textStyle,
+        position: { x: "(w-text_w)/2", y: "h*0.1" }, // 상단 10% 위치
+        fontSize: 60,
+        fontColor: "white",
+        boxColor: "black@0.6",
+        shadow: { enabled: true, x: 2, y: 2, color: "black@0.5" },
+      };
+
+      this.#renderOptions.setTextStyle(headerStyle);
+      builder.withTextFilter(
+        this.#renderOptions.createTextFilterString(this.#fontPath, cut.header)
+      );
+    }
+
+    // 본문 텍스트 필터 추가 (중앙)
+    if (cut.subtitle) {
+      const subtitleStyle = {
+        ...this.#renderOptions.getOptions().textStyle,
+        position: { x: "(w-text_w)/2", y: "h*0.5" }, // 화면 중앙
+        fontSize: 56,
+        fontColor: "white",
+        boxColor: "black@0.5",
+      };
+
+      this.#renderOptions.setTextStyle(subtitleStyle);
+      builder.withTextFilter(
+        this.#renderOptions.createTextFilterString(this.#fontPath, cut.subtitle)
+      );
+    }
+
+    // 푸터 텍스트 필터 추가 (하단)
+    if (cut.footer) {
+      const footerStyle = {
+        ...this.#renderOptions.getOptions().textStyle,
+        position: { x: "(w-text_w)/2", y: "h*0.9" }, // 하단 10% 위치
+        fontSize: 48,
+        fontColor: "white",
+        boxColor: "black@0.5",
+        shadow: { enabled: true, x: 1, y: 1, color: "black@0.4" },
+      };
+
+      this.#renderOptions.setTextStyle(footerStyle);
+      builder.withTextFilter(
+        this.#renderOptions.createTextFilterString(this.#fontPath, cut.footer)
+      );
+    }
+
+    builder.applyFilters().withOutput();
 
     return builder.execute();
   }

--- a/src/server/video-converter/ffmpeg/ffmpeg-renderer.ts
+++ b/src/server/video-converter/ffmpeg/ffmpeg-renderer.ts
@@ -144,7 +144,7 @@ export class FFmpegRenderer {
       .withOutputOptions()
       .withStartListener()
       .withProgressListener()
-      .withResizeFilter();
+      .withResizeFilterWithNoScaleUp();
 
     // 헤더 텍스트 필터 추가 (상단)
     if (cut.header) {

--- a/src/server/video-converter/model/video-cut.model.ts
+++ b/src/server/video-converter/model/video-cut.model.ts
@@ -3,5 +3,7 @@ export interface VideoCut {
   sceneId: string;
   duration: number;
   imageUrl?: string;
-  text?: string;
+  header?: string;
+  subtitle?: string;
+  footer?: string;
 }

--- a/src/server/video-converter/service/blog-to-video-job.service.ts
+++ b/src/server/video-converter/service/blog-to-video-job.service.ts
@@ -137,7 +137,7 @@ export class BlogToVideoJobService {
       return {
         duration: imageBlock.duration,
         imageUrl: imageBlock.value.src,
-        text: textBlock?.value,
+        subtitle: textBlock?.value,
         id: uuidv4(),
         sceneId: uuidv4(),
       };

--- a/src/server/video-converter/service/blog-to-video-job.service.ts
+++ b/src/server/video-converter/service/blog-to-video-job.service.ts
@@ -91,7 +91,7 @@ export class BlogToVideoJobService {
       id: uuidv4(),
       sceneId,
       duration,
-      text,
+      subtitle: text,
     };
   }
 


### PR DESCRIPTION
# 비디오 렌더링 기능 개선

## feat: header, footer 추가
- VideoCut 모델에 header, subtitle, footer 필드 추가
- 기존 text 필드를 subtitle로 변경
- 각 텍스트 영역별 스타일 및 위치 설정 추가

## test: example 코드 추가
- 비디오 렌더링 예제 코드 및 README 추가
- 테스트용 video-cuts-fixture.json 파일 추가
- 여러 컷을 하나의 비디오로 합치는 예제 구현

## feat: 이미지가 중앙에 1:1 비율로 표현되게 수정
- 이미지 리사이징 로직 개선
- 정사각형 크로핑 필터 추가
- 비디오 프레임 중앙에 이미지 배치 로직 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새 기능**
	- 비디오 렌더링 예제가 추가되어, 사용자 지정 가능한 텍스트(헤더, 자막, 풋터) 오버레이를 통한 영상 컷 생성이 가능해졌습니다.
	- 영상 처리 파이프라인이 개선되어 정사각형 크롭과 중앙 정렬 스케일링으로 출력 품질이 향상되었습니다.
  
- **문서**
	- 예제 실행 방법과 사용자 맞춤 옵션을 포함한 상세 문서가 새롭게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->